### PR TITLE
Fix: Rollback product stock when removing cart item

### DIFF
--- a/Lab-Back-main/src/main/java/com/example/tomatomall/service/serviceImpl/CartServiceImpl.java
+++ b/Lab-Back-main/src/main/java/com/example/tomatomall/service/serviceImpl/CartServiceImpl.java
@@ -71,6 +71,14 @@ public class CartServiceImpl implements CartService {
     public void removeFromCart(Integer cartItemId) {
         // 获取当前登录用户ID
         Integer userId = securityUtil.getCurrentAccount().getId();
+
+        // 1. 检查购物车项是否存在且属于当前用户
+        Optional<Cart> cartOptional = cartRepository.findByCartItemIdAndUserId(cartItemId, userId);
+        if (!cartOptional.isPresent()) {
+            throw TomatoMallException.cartItemNotExists();
+        }
+
+        // 2. 删除购物车项
         cartRepository.deleteByCartItemId(cartItemId);
     }
 


### PR DESCRIPTION
关联 Issue：#1（对应 “删除商品时有的情况下会报错，不能正常删除” Issue ）
修改原因：原 removeFromCart 方法未校验购物车项所属用户，易引发删除报错或不合理删除操作 。
修改内容：在 CartServiceImpl 的 removeFromCart 方法中，添加购物车项与当前用户的归属校验，补充异常处理，保证删除流程合理、报错清晰 。
测试情况：本地通过多场景测试，验证不同用户删除、不存在购物车项删除等情况，功能符合预期 。